### PR TITLE
Fix startup of auxiliary daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,37 @@ AREDN Supernodes provide a mechanism to connect multiple AREDN meshes together, 
 
 For easy of use, a supernode is contained in a Docker container which can be configured using a number of environmental variables:
 
-* *NODE_NAME* - This is the name for this supernode, and will be the name visible on the AREDN mesh this node directly connects to.
-* *PRIMARY_IP* - This is the primary IPv4 address for this node and should match the IP address on a network connection to a mesh.
-* *DNS_ZONE* - This is the DNS zone name for the connected mesh. Locally all AREDN networks have the zone name __local__ and domain suffix __local.mesh__. This is the global zone name (e.g. __sfwem__).
-* *DNS_SUPERNODE* - The DNS information to connect this supernode to the DNS servers of other supernodes for other meshes.  This is formatted as __zone:ipaddress__ space seperated pairs (e.g. __socalnet:1.2.3.4__ __aznet:5.6.7.8__)
-* *MESH_NETS* - List of network devices which are used to connect this supernode to a single mesh.
-* *SUPERNODE_NETS* - List of network devices which are used to connect this supernode to other supernodes.
-* *TUN0, TUN1, ... TUN31* - Each TUNx can be used to configure a vtund client or server to connect this supernode to other supernodes or a mesh network. Each configuration takes four parameters, seperated by colons, and follow AREDN naming and network convensions. For example __KN6PLV-SFMON:apassword:172.32.90.240:tunnels.xojs.org__ defines a tunnel named __KN6PLV-SFMON__ with a password __apassword__. The tunnel uses __172.32.90.240__ as its network, and connects to the tunnel server __tunnels.xojs.org__. If the tunnel server parameter is omitted, this supernode will instead create a tunnel server for another client to connect to.
-* *ENABLE_MASQUARADE* - Set to __true__ to hide the details of the supernodes behind a NAT.
-* *DISABLE_SUPERNODE* - Set to __true__ to disable the /8 rule injection into the mesh so nodes in the mesh cannot route to the supernode.
+* `NODE_NAME` - This is the name for this supernode, and will be the name
+    visible on the AREDN mesh this node directly connects to.
+* `PRIMARY_IP` - This is the primary IPv4 address for this node and should
+    match the IP address on a network connection to a mesh.
+* `DNS_ZONE` - This is the DNS zone name for the connected mesh. Locally all
+    AREDN networks have the zone name __local__ and domain suffix
+    __local.mesh__. This is the global zone name (i.e. __sfwem__).
+* `DNS_SUPERNODE` - The DNS information to connect this supernode to the
+    DNS servers of other supernodes for other meshes.  This is formatted as
+    __zone:ipaddress__ space seperated pairs (i.e. __socalnet:1.2.3.4__
+    __aznet:5.6.7.8__)
+* `MESH_NETS` - List of network devices which are used to connect this
+    supernode to a single mesh.
+* `SUPERNODE_NETS` - List of network devices which are used to connect this
+    supernode to other supernodes.
+* `TUN0`, `TUN1`, ... `TUN31` - Each TUNx can be used to configure a vtund
+    client or server to connect this supernode to other supernodes or a mesh
+    network. Each configuration takes four parameters, seperated by colons,
+    and follow AREDN naming and network convensions. For example
+    __KN6PLV-SFMON:apassword:172.32.90.240:tunnels.xojs.org__ defines a tunnel
+    named __KN6PLV-SFMON__ with a password __apassword__. The tunnel uses
+    __172.32.90.240__ as its network, and connects to the tunnel server
+    __tunnels.xojs.org__. If the tunnel server parameter is omitted, this
+    supernode will instead create a tunnel server for another client to
+    connect to.
+* `ENABLE_MASQUARADE` - Set to `true` to hide the details of the supernodes
+    behind a NAT.
+* `DISABLE_SUPERNODE` - Set to `true` to disable the /8 rule injection into
+    the mesh so nodes in the mesh cannot route to the supernode.
+* `MAXTUNNEL` - The maximum number of `TUNx` variables to look for in the
+    environment. If left unset it defaults to 31 (i.e. `TUN0` to `TUN31`).
 
 ## Building the Docker
 The Docker image is easily built:

--- a/root/setup/named.sh
+++ b/root/setup/named.sh
@@ -137,5 +137,3 @@ __EOF__
 
 # Fix rndc.key
 chmod 644 /etc/bind/rndc.key
-
-named

--- a/root/setup/olsr.sh
+++ b/root/setup/olsr.sh
@@ -110,5 +110,3 @@ done
 ip rule add pref 30220 lookup 30
 ip rule add pref 30230 lookup main
 ip rule add pref 30240 lookup 31
-
-olsrd

--- a/root/setup/vtun.sh
+++ b/root/setup/vtun.sh
@@ -22,7 +22,7 @@ __EOF__
 #
 # Loop through set of TUN0 to TUN31 variables, creating a tunnel for each valid one.
 #
-for tun in {0..${MAXTUNNEL}}
+for ((tun=0; tun<=MAXTUNNEL; tun++))
 do
   vtunr="TUN${tun}"
   vtun=${!vtunr}

--- a/root/setup/vtun.sh
+++ b/root/setup/vtun.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+MAXTUNNEL=${MAXTUNNEL:-31}
+
 # Generate VTUN client
 
 mkdir /dev/net
@@ -22,7 +24,7 @@ __EOF__
 #
 run=":"
 server=0
-for tun in {0..31}
+for tun in {0..${MAXTUNNEL}}
 do
   vtunr="TUN${tun}"
   vtun=${!vtunr}

--- a/root/startup.sh
+++ b/root/startup.sh
@@ -39,9 +39,9 @@ fi
 # shellcheck source=/dev/null
 . /setup/vtun.sh
 # shellcheck source=/dev/null
-. /setup/olsr.sh
+. /setup/olsr.sh && olsrd
 # shellcheck source=/dev/null
-. /setup/named.sh
+. /setup/named.sh && named
 # shellcheck source=/dev/null
 . /named/generate_local.sh
 

--- a/root/startup.sh
+++ b/root/startup.sh
@@ -47,7 +47,7 @@ fi
 
 # Startup any vtund clients
 MAXTUNNEL="${MAXTUNNEL:-31}"
-for tun in {0..${MAXTUNNEL}}
+for ((tun=0; tun<=MAXTUNNEL; tun++))
 do
   vtunr="TUN${tun}"
   vtun=${!vtunr}


### PR DESCRIPTION
The startup of auxiliary daemons has been moved to `startup.sh`.  This aids in debugging of the container and provides better fine grained control within the container. 